### PR TITLE
 fix: skip recipient id in toBytes for tx type 1 and 4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.2.3
+
+### Fixed
+- Skip recipient id in `toBytes` for type 1 and 4 transactions.
+
 ## 0.2.2 - 2018-07-31
 
 ### Fixed

--- a/src/Transactions/Transaction.php
+++ b/src/Transactions/Transaction.php
@@ -181,7 +181,8 @@ class Transaction
         $buffer->writeUInt32($this->timestamp);
         $buffer->writeHex($this->senderPublicKey);
 
-        if (isset($this->recipientId)) {
+        $skipRecipientId = $this->type === Types::SECOND_SIGNATURE_REGISTRATION || $this->type === Types::MULTI_SIGNATURE_REGISTRATION;
+        if (isset($this->recipientId) && !$skipRecipientId) {
             $buffer->writeHex(Base58::decodeCheck($this->recipientId)->getHex());
         } else {
             $buffer->fill(21);

--- a/tests/Concerns/Deserialize.php
+++ b/tests/Concerns/Deserialize.php
@@ -27,6 +27,7 @@ trait Deserialize
         $this->assertSame($network, $actual->network);
         $this->assertSame($expected['serialized'], Serializer::new($actual->toArray())->serialize()->getHex());
         $this->assertSameTransactions($expected, $actual, $keys);
+        $this->assertTrue($actual->verify());
 
         return $actual;
     }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `toBytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--