### PR TITLE
fix: return type of the new method

### DIFF
--- a/src/Utils/Message.php
+++ b/src/Utils/Message.php
@@ -84,7 +84,7 @@ class Message
      *
      * @param mixed $message
      *
-     * @return \ArkEcosystem\Crypto\Message
+     * @return \ArkEcosystem\Crypto\Utils\Message
      */
     public static function new($message): self
     {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Fix the DocBlock return type of Message::new() method

<!-- Why are these changes necessary? -->
It confuses library clients using the method and psalm analysis on them

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
Just change in the DocBlock, no backwards-compatibility issues expected.