### PR TITLE
fix: use correct network wif value

### DIFF
--- a/src/Networks/AbstractNetwork.php
+++ b/src/Networks/AbstractNetwork.php
@@ -14,7 +14,7 @@ abstract class AbstractNetwork extends Network
      * @see Network::$base58PrefixMap
      */
     protected $base58PrefixMap = [
-        self::BASE58_WIF           => 'aa',
+        self::BASE58_WIF           => 'aa', // 170
     ];
 
     /**

--- a/src/Networks/Devnet.php
+++ b/src/Networks/Devnet.php
@@ -7,6 +7,15 @@ namespace ArkEcosystem\Crypto\Networks;
 class Devnet extends AbstractNetwork
 {
     /**
+     * {@inheritdoc}
+     *
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_WIF           => 'ba', // 186
+    ];
+
+    /**
      * Get the chain identifier.
      *
      * @return int

--- a/src/Networks/Mainnet.php
+++ b/src/Networks/Mainnet.php
@@ -7,6 +7,15 @@ namespace ArkEcosystem\Crypto\Networks;
 class Mainnet extends AbstractNetwork
 {
     /**
+     * {@inheritdoc}
+     *
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_WIF           => 'ba', // 186
+    ];
+
+    /**
      * Get the chain identifier.
      *
      * @return int

--- a/tests/fixtures/identity.json
+++ b/tests/fixtures/identity.json
@@ -1,9 +1,9 @@
 {
     "data": {
-        "privateKey": "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712",
-        "publicKey": "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
-        "address": "0xb0FF9213f7226bBB72b84dE16af86e56f1f38B01",
+        "privateKey": "bef98d4c0e58d0e4695560594f91a349421b7cdc3e63a560470ccb259f99f087",
+        "publicKey": "023efc1da7f315f3c533a4080e491f32cd4219731cef008976c3876539e1f192d3",
+        "address": "0x6F0182a0cc707b055322CcF6d4CB6a5Aff1aEb22",
         "wif": "UdFWh1JiogHqCye7kv8RoUq9zr2z6gVsMQsZARuF7xF9JTk97NWT"
     },
-    "passphrase": "this is a top secret passphrase"
+    "passphrase": "my super secret passphrase"
 }

--- a/tests/fixtures/identity.json
+++ b/tests/fixtures/identity.json
@@ -3,7 +3,7 @@
         "privateKey": "d8839c2432bfd0a67ef10a804ba991eabba19f154a3d707917681d45822a5712",
         "publicKey": "034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192",
         "address": "0xb0FF9213f7226bBB72b84dE16af86e56f1f38B01",
-        "wif": "SGq4xLgZKCGxs7bjmwnBrWcT4C1ADFEermj846KC97FSv1WFD1dA"
+        "wif": "UdFWh1JiogHqCye7kv8RoUq9zr2z6gVsMQsZARuF7xF9JTk97NWT"
     },
     "passphrase": "this is a top secret passphrase"
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adjusts the wif value to be `ba` (186) to match testnet. Default was `aa` which is 170, which is what mainnet (Core) uses

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
