### PR TITLE
refactor: abi & keccak caching

### DIFF
--- a/src/Utils/AbiBase.php
+++ b/src/Utils/AbiBase.php
@@ -11,6 +11,10 @@ abstract class AbiBase
 {
     protected array $abi;
 
+    protected array $functionSelectorMap = [];
+
+    protected array $errorSelectorMap = [];
+
     public function __construct(ContractAbiType $type = ContractAbiType::CONSENSUS, ?string $path = null)
     {
         $abiFilePath = $this->contractAbiPath($type, $path);
@@ -18,6 +22,17 @@ abstract class AbiBase
         $abiJson = file_get_contents($abiFilePath);
 
         $this->abi = json_decode($abiJson, true)['abi'];
+
+        foreach ($this->abi as $item) {
+            $signature = $this->getFunctionSignature($item);
+            $selector  = substr($this->keccak256($signature), 2, 8);
+
+            if ($item['type'] === 'function') {
+                $this->functionSelectorMap[$selector] = $item;
+            } elseif ($item['type'] === 'error') {
+                $this->errorSelectorMap[$selector] = $item;
+            }
+        }
     }
 
     protected static function getArrayComponents(string $type): ?array

--- a/src/Utils/AbiDecoder.php
+++ b/src/Utils/AbiDecoder.php
@@ -165,36 +165,12 @@ class AbiDecoder extends AbiBase
 
     private function findFunctionBySelector(string $selector): ?array
     {
-        foreach ($this->abi as $item) {
-            if ($item['type'] !== 'function') {
-                continue;
-            }
-
-            $functionSignature = $this->getFunctionSignature($item);
-            $functionSelector  = substr($this->keccak256($functionSignature), 2, 8);
-            if ($functionSelector === $selector) {
-                return $item;
-            }
-        }
-
-        return null;
+        return $this->functionSelectorMap[$selector] ?? null;
     }
 
     private function findErrorBySelector(string $selector): ?array
     {
-        foreach ($this->abi as $item) {
-            if ($item['type'] !== 'error') {
-                continue;
-            }
-
-            $errorSignature = $this->getFunctionSignature($item);
-            $errorSelector  = substr($this->keccak256($errorSignature), 2, 8);
-            if ($errorSelector === $selector) {
-                return $item;
-            }
-        }
-
-        return null;
+        return $this->errorSelectorMap[$selector] ?? null;
     }
 
     private function decodeAbiParameters(array $params, string $data): array

--- a/src/Utils/Address.php
+++ b/src/Utils/Address.php
@@ -10,6 +10,8 @@ use kornrunner\Keccak;
 
 class Address
 {
+    private static array $cache = [];
+
     /**
      * Validate the given address.
      *
@@ -32,17 +34,23 @@ class Address
      */
     public static function toChecksumAddress(string $address): string
     {
-        $address         = strtolower(substr($address, 2));
-        $hash            = Keccak::hash($address, 256);
+        if (isset(self::$cache[$address])) {
+            return self::$cache[$address];
+        }
+
+        $rawAddress      = strtolower(substr($address, 2));
+        $hash            = Keccak::hash($rawAddress, 256);
         $checksumAddress = '0x';
 
         for ($i = 0; $i < 40; $i++) {
             if (intval($hash[$i], 16) >= 8) {
-                $checksumAddress .= strtoupper($address[$i]);
+                $checksumAddress .= strtoupper($rawAddress[$i]);
             } else {
-                $checksumAddress .= $address[$i];
+                $checksumAddress .= $rawAddress[$i];
             }
         }
+
+        self::$cache[$address] = $checksumAddress;
 
         return $checksumAddress;
     }

--- a/tests/Unit/Utils/AbiDecoderTest.php
+++ b/tests/Unit/Utils/AbiDecoderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use ArkEcosystem\Crypto\Enums\ContractAbiType;
 use ArkEcosystem\Crypto\Utils\AbiDecoder;
+use kornrunner\Keccak;
 
 it('should decode vote payload', function () {
     $decoder = new AbiDecoder();
@@ -373,3 +374,43 @@ test('should throw exception if error payload does not exist', function () {
 
     $decoder->decodeError('123456');
 })->throws(Exception::class, 'Function selector not found in ABI: 123456');
+
+test('should precompute selector maps for custom abi items', function () {
+    $decoder = new AbiDecoder(ContractAbiType::CUSTOM, dirname(__DIR__, 2).'/fixtures/mock-abi-selectors.json');
+
+    $reflector = new ReflectionObject($decoder);
+    $functions = $reflector->getProperty('functionSelectorMap');
+    $errors    = $reflector->getProperty('errorSelectorMap');
+    $functions->setAccessible(true);
+    $errors->setAccessible(true);
+
+    $functionSelector = substr(Keccak::hash('transfer(address,uint256)', 256), 0, 8);
+    $errorSelector    = substr(Keccak::hash('InsufficientBalance(uint256,uint256)', 256), 0, 8);
+
+    $functionMap = $functions->getValue($decoder);
+    $errorMap    = $errors->getValue($decoder);
+
+    expect($functionMap)->toHaveKey($functionSelector);
+    expect($functionMap[$functionSelector]['name'])->toBe('transfer');
+    expect($errorMap)->toHaveKey($errorSelector);
+    expect($errorMap[$errorSelector]['name'])->toBe('InsufficientBalance');
+});
+
+test('should decode function and error payloads using custom selector maps', function () {
+    $decoder = new AbiDecoder(ContractAbiType::CUSTOM, dirname(__DIR__, 2).'/fixtures/mock-abi-selectors.json');
+
+    $functionSelector = substr(Keccak::hash('transfer(address,uint256)', 256), 0, 8);
+    $errorSelector    = substr(Keccak::hash('InsufficientBalance(uint256,uint256)', 256), 0, 8);
+
+    $to       = 'b693449adda7efc015d87944eae8b7c37eb1690a';
+    $amount   = str_pad(dechex(7), 64, '0', STR_PAD_LEFT);
+    $data     = '0x'.$functionSelector.str_pad($to, 64, '0', STR_PAD_LEFT).$amount;
+    $decoded  = $decoder->decodeFunctionData($data);
+    $abiError = $decoder->decodeError('0x'.$errorSelector);
+
+    expect($decoded)->toBe([
+        'functionName' => 'transfer',
+        'args'         => ['0xb693449AdDa7EFc015D87944EAE8b7C37EB1690A', '7'],
+    ]);
+    expect($abiError)->toBe('InsufficientBalance');
+});

--- a/tests/Unit/Utils/AddressTest.php
+++ b/tests/Unit/Utils/AddressTest.php
@@ -34,3 +34,24 @@ it('should extract address from a byte buffer', function () {
 
     expect($actual)->toBe($fixture['data']['address']);
 });
+
+it('should convert to checksum address and cache the result', function () {
+    $address  = '0xb693449adda7efc015d87944eae8b7c37eb1690a';
+    $expected = '0xb693449AdDa7EFc015D87944EAE8b7C37EB1690A';
+
+    $reflector = new ReflectionClass(TestClass::class);
+    $cache     = $reflector->getProperty('cache');
+    $cache->setAccessible(true);
+    $cache->setValue(null, []);
+
+    $actual = TestClass::toChecksumAddress($address);
+
+    expect($actual)->toBe($expected);
+    expect($cache->getValue())->toHaveCount(1);
+    expect($cache->getValue())->toHaveKey($address);
+
+    $cached = TestClass::toChecksumAddress($address);
+
+    expect($cached)->toBe($expected);
+    expect($cache->getValue())->toHaveCount(1);
+});

--- a/tests/fixtures/mock-abi-selectors.json
+++ b/tests/fixtures/mock-abi-selectors.json
@@ -1,0 +1,38 @@
+{
+    "abi": [
+        {
+            "type": "function",
+            "name": "transfer",
+            "inputs": [
+                {
+                    "name": "to",
+                    "type": "address",
+                    "internalType": "address"
+                },
+                {
+                    "name": "amount",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+        },
+        {
+            "type": "error",
+            "name": "InsufficientBalance",
+            "inputs": [
+                {
+                    "name": "available",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                },
+                {
+                    "name": "required",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

related to https://app.clickup.com/t/86e0mk7ug

Adds static class-based caching in order to reduce repetitive calls to keccak/ABI functionality. When handling many records (e.g. a series of transactions as-per the above card), the time to perform these calls can build up.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
